### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deviocstats (3.1.9-6) unstable; urgency=medium
+
+  * Do not recommend installation of edm-iocstats anymore
+  * Use build profile to enable RTEMS cross build
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Fri, 14 Sep 2018 14:30:24 -0400
+
 deviocstats (3.1.9-5) unstable; urgency=medium
 
   * cleanup deps.

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: deviocstats
 Section: devel
 Priority: extra
 Maintainer: Michael Davidsaver <mdavidsaver@bnl.gov>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               epics-dev (>= 3.14.11-2),
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>= 1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev (>= 3.14.11-2),
                epics-msi,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme2307,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme2307 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics
 X-Epics-Targets: .*
 Standards-Version: 3.9.6
@@ -63,6 +63,7 @@ Description: CPU and Memory usage statistics for IOCs
  shipped with this support.
 
 Package: rtems-iocstats-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, ${misc:Depends},
          epics-iocstats-dev (>= ${binary:Version}),
@@ -74,6 +75,7 @@ Description: CPU and Memory usage statistics for IOCs
  This package contains support for the MVME2100 PowerPC based VME SBC.
 
 Package: rtems-iocstats-mvme2307
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, ${misc:Depends},
          epics-iocstats-dev (>= ${binary:Version}),
@@ -85,6 +87,7 @@ Description: CPU and Memory usage statistics for IOCs
  This package contains support for the MVME2307 PowerPC based VME SBC.
 
 Package: rtems-iocstats-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, ${misc:Depends},
          epics-iocstats-dev (>= ${binary:Version}),
@@ -96,6 +99,7 @@ Description: CPU and Memory usage statistics for IOCs
  This package contains support for the MVME3100 PowerPC based VME SBC.
 
 Package: rtems-iocstats-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: ${rtems:Depends}, ${misc:Depends},
          epics-iocstats-dev (>= ${binary:Version}),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,8 @@
+deviocstats source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-iocstats-mvme2100
+deviocstats source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-iocstats-mvme2307
+deviocstats source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-iocstats-mvme3100
+deviocstats source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-iocstats-mvme5500
+deviocstats source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+deviocstats source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2307 <pkg.epics-base.rtems>]
+deviocstats source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+deviocstats source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.