### PR TITLE
Don't depend on EDM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deviocstats (3.1.9-7) unstable; urgency=medium
+
+  * edm-iocstats: Don't depend on EDM anymore
+
+ -- Martin Konrad <konrad@frib.msu.edu>  Mon, 29 Oct 2018 15:06:27 -0400
+
 deviocstats (3.1.9-6) unstable; urgency=medium
 
   * Do not recommend installation of edm-iocstats anymore

--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,8 @@ Description: CPU and Memory usage statistics for IOCs
 Package: edm-iocstats
 Section: contrib/devel
 Architecture: all
-Depends: edm, ${misc:Depends},
+Depends: ${misc:Depends},
+Recommends: edm,
 Description: CPU and Memory usage statistics for IOCs
  Provides a set of device supports which collects
  statistics from the IOC it is running on.


### PR DESCRIPTION
This allows us to test this package with `piuparts` without having an EDM package available. Also, some people might just want to convert the files to their favorite display manager's format.